### PR TITLE
Dockerfile update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,26 +1,27 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 EXPOSE 8080 9100
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# kubectl
-RUN apt-get update && \
-    apt-get install -y apt-transport-https ca-certificates curl && \
-    curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update && \
-    apt-get install -y kubectl
+# kubectl & curl
+RUN apt update && \
+    apt install -y curl ca-certificates jq bash && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.26.7/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/bin/kubectl
 
 # Algorand node
 RUN mkdir /algorand
 WORKDIR /algorand
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y -q curl build-essential ca-certificates git mercurial runit vim && \
-    curl -L https://github.com/algorand/go-algorand-doc/raw/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz --output /algorand/install_master_linux-amd64.tar.gz && \
-    tar -xf install_master_linux-amd64.tar.gz && \
+SHELL ["/bin/bash", "-c"]
+RUN curl -L https://raw.githubusercontent.com/algorand/go-algorand/rel/stable/cmd/updater/update.sh --output ./update.sh && \
+    chmod -v 744 ./update.sh && \
     mkdir node && \
-    ./update.sh -i -c stable -p node -d node/_data -n && rm -rf node/_data
+    ./update.sh -i -c stable -p node -d node/_data -n && \
+    rm -rf node/_data
 
 # jq
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,10 +23,6 @@ RUN curl -L https://raw.githubusercontent.com/algorand/go-algorand/rel/stable/cm
     ./update.sh -i -c stable -p node -d node/_data -n && \
     rm -rf node/_data
 
-# jq
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y jq
-
 ADD ./scripts ./
 
 # USER 10001:10001


### PR DESCRIPTION
- Update Ubuntu to 22.04
- Use kubectl v1.26.7
- Use default Algorand install from <https://developer.algorand.org/docs/run-a-node/setup/install/#installation-with-the-updater-script>