### PR TITLE
bump app version from 3.26.2 to 4.0.1

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -38,7 +38,8 @@ jobs:
         run: |
           echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha" >> "$GITHUB_ENV"
           echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha"
-
+          echo "APP_VERSION=$(grep 'appVersion:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$(grep 'appVersion:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')"
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v5
@@ -49,7 +50,7 @@ jobs:
           push: true
           provenance: false
           tags: |
-            ghcr.io/activadigital-it/algon:${{ env.CHART_VERSION }}
+            ghcr.io/activadigital-it/algon:${{ env.APP_VERSION }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -67,8 +67,6 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-
-
       - name: Install Helm
         uses: azure/setup-helm@v4
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'charts/**'
+      - 'docker/**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Chart version
+        run: |
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')" >> "$GITHUB_ENV"
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')"
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/activadigital-it/algon:${{ env.CHART_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+  
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -74,11 +74,10 @@ jobs:
 
       - name: modify chart alpha version
         run: |
-          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha" >> "$GITHUB_ENV"
-          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha"
+          CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha
           sed -i s/version:.*/version:\ $CHART_VERSION/g charts/algon/Chart.yaml
           sed -i s/appVersion:.*/appVersion:\ $CHART_VERSION/g charts/algon/Chart.yaml
-          
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -75,7 +75,6 @@ jobs:
         run: |
           CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha
           sed -i s/version:.*/version:\ $CHART_VERSION/g charts/algon/Chart.yaml
-          sed -i s/appVersion:.*/appVersion:\ $CHART_VERSION/g charts/algon/Chart.yaml
         
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,4 +1,4 @@
-name: release
+name: release-dev
 
 on:
   push:
@@ -67,9 +67,18 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+
+
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: modify chart alpha version
+        run: |
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha" >> "$GITHUB_ENV"
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha"
+          sed -i s/version:.*/version:\ $CHART_VERSION/g charts/algon/Chart.yaml
+          sed -i s/appVersion:.*/appVersion:\ $CHART_VERSION/g charts/algon/Chart.yaml
+          
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -82,3 +82,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-{{ .Version }}-alpha"

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Get Chart version
         run: |
-          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')" >> "$GITHUB_ENV"
-          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')"
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha" >> "$GITHUB_ENV"
+          echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha"
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -70,8 +70,14 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+
+      - name: modify chart alpha version
+        run: |
+          CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha
+          sed -i s/version:.*/version:\ $CHART_VERSION/g charts/algon/Chart.yaml
+          sed -i s/appVersion:.*/appVersion:\ $CHART_VERSION/g charts/algon/Chart.yaml
+        
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-{{ .Version }}-alpha"

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -72,12 +72,6 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
-      - name: modify chart alpha version
-        run: |
-          CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')-alpha
-          sed -i s/version:.*/version:\ $CHART_VERSION/g charts/algon/Chart.yaml
-          sed -i s/appVersion:.*/appVersion:\ $CHART_VERSION/g charts/algon/Chart.yaml
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,8 @@ jobs:
         run: |
           echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')" >> "$GITHUB_ENV"
           echo "CHART_VERSION=$(grep 'version:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')"
-
+          echo "APP_VERSION=$(grep 'appVersion:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$(grep 'appVersion:' charts/algon/Chart.yaml|cut -f2 -d ':'|tr -d ' ')"
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -88,3 +88,40 @@ The algon docker image is hosted on GHCR:
 ```
 docker pull ghcr.io/activadigital-it/algon
 ```
+
+## "goal node status" output
+
+### Catching up
+
+```shell
+root@algon-0:/algorand/node# ./goal node status
+Last committed block: 45350850
+Sync Time: 1852.7s
+Catchpoint: 45340000#GRJKAFLZKHGSNFTFJ6CGYF5V6ANVAEBKTMTFPTPWMH5DKBJEFWWQ
+Catchpoint total accounts: 2123933
+Catchpoint accounts processed: 2123933
+Catchpoint accounts verified: 2123933
+Catchpoint total KVs: 13835275
+Catchpoint KVs processed: 13835275
+Catchpoint KVs verified: 13835275
+Catchpoint total blocks: 1321
+Catchpoint downloaded blocks: 1321
+Genesis ID: testnet-v1.0
+Genesis hash: hashHASHhashHASHhash
+```
+
+### Running
+
+```shell
+root@algon-0:/algorand/node# ./goal node status
+Last committed block: 45342234
+Time since last block: 0.0s
+Sync Time: 14.1s
+Last consensus protocol: https://github.com/algorandfoundation/specs/tree/XXXXXXXXXXXXXXX
+Next consensus protocol: https://github.com/algorandfoundation/specs/tree/XXXXXXXXXXXXXXX
+Round for next consensus protocol: 45342235
+Next consensus protocol supported: true
+Last Catchpoint: 
+Genesis ID: testnet-v1.0
+Genesis hash: hashHASHhashHASHhash
+```

--- a/charts/algon/Chart.yaml
+++ b/charts/algon/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.1-alpha
+version: 4.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/algon/Chart.yaml
+++ b/charts/algon/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.1-alpha
+version: 4.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.0.1-alpha
+appVersion: 4.0.1

--- a/charts/algon/Chart.yaml
+++ b/charts/algon/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.26.2
+version: 4.0.1-alpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.26.0
+appVersion: 4.0.1-alpha

--- a/charts/algon/Chart.yaml
+++ b/charts/algon/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: algon
 description: Stable channel Algorand node helm chart
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -11,12 +10,10 @@ description: Stable channel Algorand node helm chart
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.1
-
+version: 4.0.1-alpha
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/algon/values.yaml
+++ b/charts/algon/values.yaml
@@ -20,7 +20,7 @@ algorand:
   network: testnet
   config:
     algod:
-      Version: 33
+      Version: 35
       BaseLoggerDebugLevel: 3
       DNSSecurityFlags: 0
       LogArchiveMaxAge: "1h"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-# 4-0-1
+# 4-0-1-dev
 EXPOSE 8080 9100
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-# 4-0-1-dev
+# 4-0-1-dev 1
 EXPOSE 8080 9100
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-
+# 4-0-1
 EXPOSE 8080 9100
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-# 4-0-1-dev 1
+# 4-0-1
 EXPOSE 8080 9100
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
     apt install -y curl ca-certificates jq bash bind9-dnsutils && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.26.7/bin/linux/amd64/kubectl && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/docker/scripts/start_all.sh
+++ b/docker/scripts/start_all.sh
@@ -24,6 +24,7 @@ else
     echo `kubectl get secrets/algon-api-token -o json  | jq .data | jq -r '."algod.token"' | base64 -d` >  node/data/algod.token
     echo `kubectl get secrets/algon-api-token -o json  | jq .data | jq -r '."algod.admin.token"' | base64 -d` >  node/data/algod.admin.token
 fi
+export ALGON_TOKEN="$(cat node/data/algod.token)"
 export token=
 
 echo "INFO: Algod Node current status"
@@ -31,5 +32,8 @@ echo "INFO: Algod Node current status"
 echo "INFO: Fast catchup only if more than 10000 rounds are missing."
 /algorand/node/goal node catchup --force -m 10000 &
 
-# Do not kill the pod
-sleep infinity
+# Do not kill the pod and print a JSON status line every minute
+while true; do
+    curl --location "http://localhost:8080/v2/status?format=json" --header 'Content-Type: application/json' --header 'Accept: application/json' --header "X-Algo-API-Token: ${ALGON_TOKEN}"
+    sleep 60
+done

--- a/docker/scripts/start_all.sh
+++ b/docker/scripts/start_all.sh
@@ -4,12 +4,14 @@ set -e
 
 # Start algod
 cp node/genesisfiles/${ALGORAND_NETWORK}/genesis.json ${ALGORAND_DATA}
+echo "INFO: Starting Algod"
 /algorand/node/algod -l 0.0.0.0:8080 &
 sleep 5
 
 # Store algod.token and algod.admin.token in kubernetes secret. Tokens are shared among node instances when replicas are greater than 1. 
 export token=`kubectl get secrets/algon-api-token -o json  | jq .data | jq -r '."algod.token"' | base64 -d`
 if [ "$token" = "null" ]; then
+    echo "INFO: Algod Token(s) not found, creating new ones in cluster,"
     kubectl create secret generic algon-api-token \
                 --from-file=node/data/algod.token \
                 --from-file=node/data/algod.admin.token \
@@ -18,14 +20,16 @@ if [ "$token" = "null" ]; then
                 -o yaml |
                 kubectl apply -f -
 else
+    echo "INFO: Algod Tokens found in cluster, refreshing local copy."
     echo `kubectl get secrets/algon-api-token -o json  | jq .data | jq -r '."algod.token"' | base64 -d` >  node/data/algod.token
     echo `kubectl get secrets/algon-api-token -o json  | jq .data | jq -r '."algod.admin.token"' | base64 -d` >  node/data/algod.admin.token
 fi
 export token=
 
-# Fast catchup
+echo "INFO: Algod Node current status"
 /algorand/node/goal node status
-/algorand/node/goal node catchup --force &
+echo "INFO: Fast catchup only if more than 10000 rounds are missing."
+/algorand/node/goal node catchup --force -m 10000 &
 
 # Do not kill the pod
 sleep infinity

--- a/docker/scripts/start_all.sh
+++ b/docker/scripts/start_all.sh
@@ -32,8 +32,9 @@ echo "INFO: Algod Node current status"
 echo "INFO: Fast catchup only if more than 10000 rounds are missing."
 /algorand/node/goal node catchup --force -m 10000 &
 
+sleep 1
 # Do not kill the pod and print a JSON status line every minute
 while true; do
-    curl --location "http://localhost:8080/v2/status?format=json" --header 'Content-Type: application/json' --header 'Accept: application/json' --header "X-Algo-API-Token: ${ALGON_TOKEN}"
+    curl -sS --location "http://localhost:8080/v2/status?format=json" --header 'Content-Type: application/json' --header 'Accept: application/json' --header "X-Algo-API-Token: ${ALGON_TOKEN}"
     sleep 60
 done


### PR DESCRIPTION
Major Changes:
- move from 3.26.2 to 4.0.1 version of Algorand release
Minor Changes:
- add release workflow on dev branch, using "-alpha" notation in generating helm chart
- docker tagging based on appVersion on Chart.yaml, instead of version
- logging on algon pod status retrieved by algorand api status, more readability
- changed kubectl image on algorand pod